### PR TITLE
Don't overwrite existing zshrc

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,13 +19,13 @@
     file: path=~/bin/ state=directory
     become: no
     
-  - name: determine if .zshrc already exist
+  - name: Determine whether .conf/zshrc exist
     stat:
       path: ~/.conf/zshrc
     register: zshrc_exists
     become: no
 
-  - name: deploy .zshrc
+  - name: Deploy .zshrc
     template: src=zshrc.in dest=~/.conf/zshrc
     become: no
     when: zshrc_exists.stat.exists == False 
@@ -38,7 +38,7 @@
     command: mv ~/.zshrc ~/.zshrc.bak
     when: standard_zshrc_stat.stat.exists
   
-  - name: symlink zshrc
+  - name: Symlink zshrc
     file: path=~/.zshrc src=~/.conf/zshrc state=link
     become: no
     

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,10 +30,14 @@
     become: no
     when: zshrc_exists.stat.exists == False 
     
-  - name: remove standard zshrc
-    file: path=~/.zshrc state=absent
-    become: no
-    
+  - name: Determine whether standard .zshrc exist
+    stat: path=~/.zshrc
+    register: standard_zshrc_stat
+
+  - name: Rename standard .zshrc
+    command: mv ~/.zshrc ~/.zshrc.bak
+    when: standard_zshrc_stat.stat.exists
+  
   - name: symlink zshrc
     file: path=~/.zshrc src=~/.conf/zshrc state=link
     become: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,9 +19,16 @@
     file: path=~/bin/ state=directory
     become: no
     
+  - name: determine if .zshrc already exist
+    stat:
+      path: ~/.conf/zshrc
+    register: zshrc_exists
+    become: no
+
   - name: deploy .zshrc
     template: src=zshrc.in dest=~/.conf/zshrc
     become: no
+    when: zshrc_exists.stat.exists == False 
     
   - name: remove standard zshrc
     file: path=~/.zshrc state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     become: no
 
   - name: Create conf folder in home directory
-    file: path=~/conf/ state=directory
+    file: path=~/.conf/ state=directory
     become: no
 
   - name: Create bin folder in home directory
@@ -20,7 +20,7 @@
     become: no
     
   - name: deploy .zshrc
-    template: src=zshrc.in dest=~/conf/zshrc
+    template: src=zshrc.in dest=~/.conf/zshrc
     become: no
     
   - name: remove standard zshrc
@@ -28,7 +28,7 @@
     become: no
     
   - name: symlink zshrc
-    file: path=~/.zshrc src=~/conf/zshrc state=link
+    file: path=~/.zshrc src=~/.conf/zshrc state=link
     become: no
     
   - name: Set zsh as default shell (Ubuntu)


### PR DESCRIPTION
This PR adds numerous fixes to make multiple runs of the role safer:
 - Only install the template zshrc if there is not already such file
 - Rename the `~/.zshrc` standard file instead of removing it

Also a few minor tweaks
 - Store the config files in a hidden folder
 - Capitalize all the tasks for consistency