### PR TITLE
Use "new" apt -> name: [pkg1, pkg2, ...] syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,8 @@
 ---
   - name: Ensure zsh is installed
-    apt: name={{item}} state=present
-    with_items:
-      - git
-      - git-core
-      - zsh
+    apt:
+      name: [git, git-core, zsh]
+      state: present
     when: ansible_os_family == 'Debian'
 
   - name: Clone oh-my-zsh repo


### PR DESCRIPTION
The updates the syntax for installing multiple apt packages.

Fixes #7 